### PR TITLE
Remove compile errors on T4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 __pycache__
+*.vcxitems

--- a/gdbstub.cpp
+++ b/gdbstub.cpp
@@ -531,13 +531,13 @@ int process_P(const char *cmd, char *result) {
  * @return int 1 = valid; 0 = invalid
  */
 int isValidAddress(uint32_t addr, int sz=0) {
-  if (addr >= RAM_START && addr <= RAM_END) {
-    if (addr+sz-1 >= RAM_START && addr+sz-1 <= RAM_END) {
+  if (addr >= (uint32_t)RAM_START && addr <= (uint32_t)RAM_END) {
+    if (addr+sz-1 >= (uint32_t)RAM_START && addr+sz-1 <= (uint32_t)RAM_END) {
       return 1;
     }
   }
-  else if (addr >= FLASH_START && addr <= FLASH_END) {
-    if (addr+sz-1 >= FLASH_START && addr+sz-1 <= FLASH_END) {
+  else if (addr >= (uint32_t)FLASH_START && addr <= (uint32_t)FLASH_END) {
+    if (addr+sz-1 >= (uint32_t)FLASH_START && addr+sz-1 <= (uint32_t)FLASH_END) {
       return 1;
     }
   }


### PR DESCRIPTION
There are a couple wasys of doing it.  Your code was comparing an address to a uint32_t value... So I simply did cast of the address to uint32_t...

Other option would be to change your definitions of things like FLASH_START to simply be a uint32_t.

Warning it also include a change to .gitignore as to keep changes brought in by VisualMicro to being uploaded to project

Feel free to not take this fix... 