### PR TITLE
add definitions for the Teensy 3.6

### DIFF
--- a/extras/teensy_debug
+++ b/extras/teensy_debug
@@ -213,7 +213,7 @@ def createFiles(AVR):
   print("Create %s" % (board))
   with open(board, mode) as f:
     f.write("menu.gdb=GDB\n")
-    for ver in ('41','40','31'):
+    for ver in ('41','40','31','36'):
       f.write("""
 teensy%s.menu.gdb.serial=Take over Serial
 teensy%s.menu.gdb.serial.build.gdb=2

--- a/src/TeensyDebug.h
+++ b/src/TeensyDebug.h
@@ -12,9 +12,9 @@
 #ifndef TEENSY_DEBUG_H
 #define TEENSY_DEBUG_H
 
-// is this a Teensy 3.2? If so, we can support hardware interrupts
+// is this a Teensy 3.2 or Teensy 3.6? If so, we can support hardware interrupts
 // and should hijack setup() to set that up.
-#ifdef __MK20DX256__
+#if defined(__MK20DX256__) || defined(__MK66FX1M0__)
 #define HAS_FP_MAP
 #endif
 
@@ -28,6 +28,13 @@
 #define FLASH_END ((void*)0x00040000)
 #define RAM_START ((void*)0x1FFF8000)
 #define RAM_END   ((void*)0x2FFFFFFF)
+#endif
+
+#ifdef __MK66FX1M0__
+#define FLASH_START ((void*)0x0)
+#define FLASH_END ((void*)0x000FFFFF)
+#define RAM_START ((void*)0x1FFF0000)
+#define RAM_END   ((void*)0x2002FFFF)
 #endif
 
 #ifdef __IMXRT1062__


### PR DESCRIPTION
Based on @firelizzard18’s work in
https://github.com/ftrias/TeensyDebug/issues/4#issuecomment-783658913,
I verified that debugging functions works both in RAM and in flash:

```
"/home/michael/Downloads/arduino-1.8.13/hardware/teensy/../tools/arm/bin//arm-none-eabi-gdb" -ex "target extended-remote /dev/ttyACM1" "/tmp/arduino_build_978572/gdb.ino.elf"

GNU gdb (GNU Tools for ARM Embedded Processors) 7.10.1.20160923-cvs
Copyright (C) 2015 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "--host=x86_64-linux-gnu --target=arm-none-eabi".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
/home/michael/.gdbinit:47: Error in sourced command file:
Scripting in the "Python" language is not supported in this copy of GDB.
Reading symbols from /tmp/arduino_build_978572/gdb.ino.elf...done.
Remote debugging using /dev/ttyACM1
HardwareSerial::addToSerialEventsList (
    this=0x0 <HardwareSerial::addToSerialEventsList()>)
    at /home/michael/Downloads/arduino-1.8.13/hardware/teensy/avr/cores/teensy3/HardwareSerial.cpp:42
42		s_serials_with_serial_events[s_count_serials_with_serial_events++] = this;
(gdb) b test_function
Breakpoint 1 at 0x49c: file /home/michael/Arduino/gdb/gdb.ino, line 13.
(gdb) c
Continuing.

Breakpoint 1, test_function () at /home/michael/Arduino/gdb/gdb.ino:13
13	void test_function() {
(gdb) bt
 #0  test_function () at /home/michael/Arduino/gdb/gdb.ino:13
 #1  0x000004d0 in loop () at /home/michael/Arduino/gdb/gdb.ino:21
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
(gdb)
```