### PR TITLE
Renaming `halt()` to `halt_cpu()` to eliminate conflicts with SD libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ void setup() {
 
   // debug.begin(Serial1);   // or use physical serial port
 
-  halt();                    // stop on startup; if not, Teensy keeps running and you
+  halt_cpu();                    // stop on startup; if not, Teensy keeps running and you
                              // have to set a breakpoint or use Ctrl-C.
 }
 

--- a/src/TeensyDebug.h
+++ b/src/TeensyDebug.h
@@ -157,7 +157,7 @@ extern Debug debug;
 
 #define breakpoint(n) {if (hcdebug_isEnabled(n)) {asm volatile("svc #0x11");}}
 #define breakpoint_enable(n) {hcdebug_setBreakpoint(n);}
-#define halt() {asm volatile("svc #0x11");}
+#define halt_cpu() {asm volatile("svc #0x11");}
 // #define triggerBreakpoint() { NVIC_SET_PENDING(IRQ_SOFTWARE); }
 #define DEBUGRUN __attribute__ ((section(".fastrun"), noinline, noclone ))
 


### PR DESCRIPTION
…`halt_cpu()` to eliminate conflicts with SD libraries.