### PR TITLE
Allow read-out of EXTMEM on Teensy 4.1

### DIFF
--- a/src/TeensyDebug.h
+++ b/src/TeensyDebug.h
@@ -47,6 +47,8 @@
 #define FLASH_END ((void*)0x601f0000) // only true for Teensy 4.0
 #define RAM_START ((void*)0x00000020)
 #define RAM_END   ((void*)0x20280000)
+extern unsigned long _extram_start;
+extern uint8_t external_psram_size;
 #endif
 
 #include <usb_desc.h>
@@ -61,6 +63,12 @@
 
 #if defined(HAS_FP_MAP) || defined(GDB_DUAL_SERIAL) || defined(GDB_TAKE_OVER_SERIAL)
 #define REMAP_SETUP
+#endif
+
+// Define a symbol if GDB is enabled in the Arduino IDE: helps
+// with conditional compilation for e.g. halt_cpu()
+#if defined(GDB_DUAL_SERIAL) || defined(GDB_TAKE_OVER_SERIAL) || defined(GDB_MANUAL_SELECTION)
+#define GDB_IS_ENABLED
 #endif
 
 // If this is used internally, not need to remap

--- a/src/TeensyDebug.h
+++ b/src/TeensyDebug.h
@@ -47,8 +47,16 @@
 #define FLASH_END ((void*)0x601f0000) // only true for Teensy 4.0
 #define RAM_START ((void*)0x00000020)
 #define RAM_END   ((void*)0x20280000)
+#if defined(ARDUINO_TEENSY41)
 extern unsigned long _extram_start;
 extern uint8_t external_psram_size;
+#undef FLASH_END 
+#define FLASH_END ((void*)0x607c0000) // only true for Teensy 4.1
+#endif // defined(ARDUINO_TEENSY41)
+#if defined(ARDUINO_TEENSY_MICROMOD)
+#undef FLASH_END 
+#define FLASH_END ((void*)0x60fc0000) // only true for Teensy MM
+#endif // defined(ARDUINO_TEENSY41)
 #endif
 
 #include <usb_desc.h>

--- a/src/gdbstub.cpp
+++ b/src/gdbstub.cpp
@@ -541,7 +541,8 @@ int isValidAddress(uint32_t addr, int sz=0) {
       return 1;
     }
   }
-#if defined(__IMXRT1062__)
+  
+#if defined(ARDUINO_TEENSY41)
   // allow read-out of EXTMEM if it is fitted
   else if (external_psram_size > 0) // EXTMEM size in MBytes
   {
@@ -553,7 +554,7 @@ int isValidAddress(uint32_t addr, int sz=0) {
       }
     }
   }
-#endif // defined(__IMXRT1062__)
+#endif // defined(ARDUINO_TEENSY41)
   
   return 0;
 }

--- a/src/gdbstub.cpp
+++ b/src/gdbstub.cpp
@@ -541,6 +541,20 @@ int isValidAddress(uint32_t addr, int sz=0) {
       return 1;
     }
   }
+#if defined(__IMXRT1062__)
+  // allow read-out of EXTMEM if it is fitted
+  else if (external_psram_size > 0) // EXTMEM size in MBytes
+  {
+    if (addr >= (uint32_t) &_extram_start && addr <= (uint32_t) (&_extram_start + (external_psram_size * 256 * 1024))) 
+    {
+      if (addr+sz-1 >= (uint32_t) &_extram_start && addr+sz-1 <= (uint32_t) (&_extram_start + (external_psram_size * 256 * 1024))) 
+      {
+        return 1;
+      }
+    }
+  }
+#endif // defined(__IMXRT1062__)
+  
   return 0;
 }
 


### PR DESCRIPTION
It's helpful to be able to look at the contents of EXTMEM / PSRAM on a Teensy 4.1, if you have it fitted. This change enables that capability by modifying isValidAddress(), but does not allow access if not fitted.

Also defines GDB_IS_ENABLED to simplify conditional compilation in users' applications, e.g. for omitting a call to halt_cpu() if compiled without GDB enabled.