### PR TITLE
Re-enable writes to ITCM, so breakpoints work again

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TeensyDebug
-version=0.0.2
+version=0.0.3
 author=Fernando Trias
 maintainer=Fernando Trias
 sentence=Debugging using GDB on PJRC Teensy.

--- a/src/TeensyDebug.cpp
+++ b/src/TeensyDebug.cpp
@@ -816,7 +816,7 @@ void debug_call_isr() {
   asm volatile(SAVE_REGISTERS);
   __enable_irq();
   asm volatile("push {lr}");
-  NVIC_CLEAR_PENDING(IRQ_DEBUG);
+  NVIC_CLEAR_PENDING(IRQ_SOFTWARE);
 
   // Are we in debug mode? If not, just jump to original ISR
   if (debugenabled == 0) {
@@ -863,7 +863,7 @@ void debug_call_isr_setup() {
   debugcount++;
   debugenabled = 1;
   // process in lower priority so services can keep running
-  NVIC_SET_PENDING(IRQ_DEBUG); 
+  NVIC_SET_PENDING(IRQ_SOFTWARE); 
 }
 
 #if 1
@@ -1209,11 +1209,11 @@ void debug_init() {
   _VectorsRam[11] = svcall_isr;
 
   // chain the software ISR handler
-  original_software_isr = _VectorsRam[IRQ_DEBUG + 16];
+  original_software_isr = _VectorsRam[IRQ_SOFTWARE + 16];
 
-  _VectorsRam[IRQ_DEBUG + 16] = debug_call_isr;
-  NVIC_SET_PRIORITY(IRQ_DEBUG, 208); // 255 = lowest priority
-  NVIC_ENABLE_IRQ(IRQ_DEBUG);
+  _VectorsRam[IRQ_SOFTWARE + 16] = debug_call_isr;
+  NVIC_SET_PRIORITY(IRQ_SOFTWARE, 208); // 255 = lowest priority
+  NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
 
   debug_initBreakpoints();
 }

--- a/src/TeensyDebug.cpp
+++ b/src/TeensyDebug.cpp
@@ -1179,6 +1179,15 @@ void debug_init() {
 //  dumpmem(xtable, 32);
 #endif
 
+  // Recent startup.c has disabled writes to ITCM - re-enable those
+  // Various macros cribbed from there...
+#define READWRITE	SCB_MPU_RASR_AP(3)
+#define MEM_NOCACHE	SCB_MPU_RASR_TEX(1)
+#define SIZE_512K	(SCB_MPU_RASR_SIZE(18) | SCB_MPU_RASR_ENABLE)
+#define REGION(n)	(SCB_MPU_RBAR_REGION(n) | SCB_MPU_RBAR_VALID)
+  SCB_MPU_RBAR = 0x00000000 | REGION(1); // *** assumed *** ITCM
+  SCB_MPU_RASR = MEM_NOCACHE | READWRITE | SIZE_512K;
+
   debug_trace = 1;
 
   _VectorsRam[2] = call_nmi_isr;

--- a/src/TeensyDebug.cpp
+++ b/src/TeensyDebug.cpp
@@ -816,7 +816,7 @@ void debug_call_isr() {
   asm volatile(SAVE_REGISTERS);
   __enable_irq();
   asm volatile("push {lr}");
-  NVIC_CLEAR_PENDING(IRQ_SOFTWARE);
+  NVIC_CLEAR_PENDING(IRQ_DEBUG);
 
   // Are we in debug mode? If not, just jump to original ISR
   if (debugenabled == 0) {
@@ -863,7 +863,7 @@ void debug_call_isr_setup() {
   debugcount++;
   debugenabled = 1;
   // process in lower priority so services can keep running
-  NVIC_SET_PENDING(IRQ_SOFTWARE); 
+  NVIC_SET_PENDING(IRQ_DEBUG); 
 }
 
 #if 1
@@ -1209,11 +1209,11 @@ void debug_init() {
   _VectorsRam[11] = svcall_isr;
 
   // chain the software ISR handler
-  original_software_isr = _VectorsRam[IRQ_SOFTWARE + 16];
+  original_software_isr = _VectorsRam[IRQ_DEBUG + 16];
 
-  _VectorsRam[IRQ_SOFTWARE + 16] = debug_call_isr;
-  NVIC_SET_PRIORITY(IRQ_SOFTWARE, 208); // 255 = lowest priority
-  NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
+  _VectorsRam[IRQ_DEBUG + 16] = debug_call_isr;
+  NVIC_SET_PRIORITY(IRQ_DEBUG, 208); // 255 = lowest priority
+  NVIC_ENABLE_IRQ(IRQ_DEBUG);
 
   debug_initBreakpoints();
 }


### PR DESCRIPTION
Teensyduino 1.59 disabled writes to ITCM (code memory) as a security measure, but this means we can't set breakpoints any more. This code re-enables them in debug_init().

Apologies, git seems to have suddenly decided that every line in the file has changed, even when they haven't. I think it's a line-ending thing...